### PR TITLE
Fixed comparable elements in line 313

### DIFF
--- a/Relations.md
+++ b/Relations.md
@@ -267,8 +267,9 @@ In partially ordered sets, two elements are said to be "comparable" if one is le
 : Two elements `a` and `b` in a poset are incomparable if neither `a` is less than or equal to `b`, nor `b` is less than or equal to `a`.
 
 #### Example:
-Consider the set of integers `Z` with the partial order relation "less than or equal to." In this poset, any two distinct elements are either comparable or incomparable. For example, `1` and `3` are incomparable because neither `1 ≤ 3` nor `3 ≤ 1` is true. On the other hand, `1` and `-1` are comparable because `1 ≤ -1` is false, but `-1 ≤ 1` is true.
+Consider the set of integers `Z` with the partial order relation "less than or equal to." In this poset, any two distinct elements are either comparable or incomparable. For example, `1` and `3` are comparable because `3 ≤ 1` is false, but `1 ≤ 3` is true, and `1` and `-1` are comparable because `1 ≤ -1` is false, but `-1 ≤ 1` is true.
 
+On the other hand, consider the set of integers `Z` with the partial order relation "*a* divides *b*". That is to say, *a* relates to *b* iff `a|b` (a divides b). `2` and `4` are comparable because `4|2`*(meaning 2 divided by 4 has a remainder)* is false, but `2|4`*(meaning 4 divided by 2 has no remainder)* is true. However, `3` and `5` are incomparable because neither `3|5` nor `5|3` are true. *(5/3 and 3/5 both have remainders)*.
 #### Tricky Things to Remember:
 - Not all elements in a poset are comparable. Some pairs of elements may be incomparable.
 - The concept of comparability is important because it allows us to define minimum and maximum elements in a poset, and it is also used in algorithms such as topological sorting.

--- a/Study_Guide.md
+++ b/Study_Guide.md
@@ -310,7 +310,7 @@ In partially ordered sets, two elements are said to be "comparable" if one is le
 : Two elements `a` and `b` in a poset are incomparable if neither `a` is less than or equal to `b`, nor `b` is less than or equal to `a`.
 
 ##### Example:
-Consider the set of integers `Z` with the partial order relation "less than or equal to." In this poset, any two distinct elements are either comparable or incomparable. For example, `1` and `3` are incomparable because neither $1 <= 3$ nor $3 <= 1$ is true. On the other hand, `1` and `-1` are comparable because $1 <= -1$ is false, but $-1 <= 1$ is true.
+Consider the set of integers `Z` with the partial order relation "less than or equal to." In this poset, any two distinct elements are either comparable or incomparable. For example, `1` and `3` are comparable because $1 <= 3$ is true, even though $3 <= 1$ is false. `1` and `-1` are comparable because $1 <= -1$ is false, but $-1 <= 1$ is true.
 
 ##### Tricky Things to Remember:
 - Not all elements in a poset are comparable. Some pairs of elements may be incomparable.


### PR DESCRIPTION
Originally said 1 and 3 were not comparable because 1<=3 was false and 3<=1 was false. But 1<=3 is true, so the elements are comparable.